### PR TITLE
feat: add eugo toolchain dev container (.devcontainer + .mcp.json)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+# eugo toolchain dev container for eugo-inc forks — develop/build the fork with the eugo
+# toolchain (clang/cmake/meson/cuda) + GPU + Claude Code/MCP. Image coords are ARGs; override
+# via devcontainer.json build.args. Pulling this image needs ECR access to account 411727469413.
+ARG EUGO_ECR_ACCOUNT=411727469413
+ARG EUGO_ECR_REGION=us-east-1
+ARG EUGO_IMAGE_REPO=slava_mega_test
+ARG EUGO_IMAGE_TAG=ray-meson-perf-debug
+ARG EUGO_IMAGE_DIGEST=sha256:c2b359973236d8ccf042f69abf60324cc7a26a51e1bdb93b5ccb3cf4cc95fff7
+FROM ${EUGO_ECR_ACCOUNT}.dkr.ecr.${EUGO_ECR_REGION}.amazonaws.com/${EUGO_IMAGE_REPO}:${EUGO_IMAGE_TAG}@${EUGO_IMAGE_DIGEST}
+
+# The base already ships node/npm (for the GitHits MCP) but not the Docker CLI — add the static
+# Docker CLI (for the eugo-kb MCP's `docker exec` against the host socket bind-mounted in
+# devcontainer.json). Also no-op the base's BASH_ENV helper, which is absent in forks.
+ARG DOCKER_CLI_VERSION=29.5.3
+RUN <<EOT
+set -eux
+curl -fsSL "https://download.docker.com/linux/static/stable/aarch64/docker-${DOCKER_CLI_VERSION}.tgz" \
+  | tar xz -C /usr/local/bin --strip-components=1 docker/docker
+# The base's BASH_ENV sources /usr/local/bin/eugo_shared.inc, which is a DANGLING symlink in a
+# fork (the eugo scripts aren't present) — every non-interactive shell warns. Replace it with an
+# empty no-op file (rm the dangling link first; writing through it would ENOENT).
+rm -f /usr/local/bin/eugo_shared.inc
+: > /usr/local/bin/eugo_shared.inc
+docker --version
+node --version
+EOT

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+    "name": "${localWorkspaceFolderBasename} (eugo toolchain)",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "options": [
+            "--platform=linux/arm64"
+        ]
+    },
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "runArgs": [
+        "--platform=linux/arm64",
+        "--shm-size=12g",
+        "--runtime=nvidia",
+        "--cap-add=SYS_PTRACE",
+        "--security-opt=seccomp=unconfined"
+    ],
+    "mounts": [
+        "source=eugo-claude-config,target=/root/.claude,type=volume",
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    ],
+    "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}; bash .devcontainer/post-create.sh",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "llvm-vs-code-extensions.vscode-clangd",
+                "ms-vscode.cmake-tools",
+                "mesonbuild.mesonbuild",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-python.debugpy",
+                "charliermarsh.ruff",
+                "tamasfe.even-better-toml",
+                "redhat.vscode-yaml",
+                "anthropic.claude-code",
+                "github.vscode-pull-request-github"
+            ],
+            "settings": {
+                "C_Cpp.intelliSenseEngine": "disabled",
+                "terminal.integrated.defaultProfile.linux": "bash"
+            }
+        }
+    }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# MARK: post-create — eugo toolchain dev container for eugo-inc forks.
+# Tolerant by design: prints diagnostics, never fails the create.
+set +e
+
+echo "[devcontainer] $(clang --version 2>/dev/null | head -1)"
+echo "[devcontainer] $(cmake --version 2>/dev/null | head -1)"
+
+# eugo-kb MCP needs the in-container Docker CLI + the host socket (bind-mounted) + the
+# eugo-kb-tools container running on the host.
+if command -v docker >/dev/null 2>&1 && docker ps >/dev/null 2>&1; then
+  echo "[devcontainer] host Docker reachable (CLI + socket)"
+  docker ps --format '{{.Names}}' 2>/dev/null | grep -qx eugo-kb-tools \
+    && echo "[devcontainer] eugo-kb MCP backend (eugo-kb-tools) reachable" \
+    || echo "[devcontainer] note: 'eugo-kb-tools' not running on the host — start it for the eugo-kb MCP"
+else
+  echo "[devcontainer] note: docker CLI/socket not ready — eugo-kb MCP unavailable"
+fi
+command -v npx >/dev/null 2>&1 \
+  && echo "[devcontainer] node/npx OK (GitHits MCP)" \
+  || echo "[devcontainer] note: npx missing — GitHits MCP unavailable"
+[ -d "$HOME/.claude" ] \
+  && echo "[devcontainer] ~/.claude persisted at $HOME/.claude" \
+  || echo "[devcontainer] note: run 'claude' once to log in (persists via the eugo-claude-config volume)"
+
+true

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "GitHits": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "githits@latest",
+        "mcp",
+        "start"
+      ]
+    },
+    "eugo-kb": {
+      "command": "docker",
+      "args": [
+        "exec",
+        "-i",
+        "eugo-kb-tools",
+        "/opt/miniforge3/envs/eugo_kb/bin/eugo-mcp"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a VSCode **Dev Container** that builds this fork with the eugo toolchain image
(clang / cmake / meson / CUDA) + GPU passthrough + Claude Code and the eugo-kb / GitHits MCP servers.

- `.devcontainer/` (or `.devcontainer/eugo/` where an upstream `.devcontainer/` already exists):
  `devcontainer.json` + `Dockerfile` (pins the eugo dev image; ARG-overridable) + `post-create.sh`.
- `.mcp.json`: `eugo-kb` (`docker exec` to the host `eugo-kb-tools`) + `GitHits` (`npx`).

Base image `411727469413.dkr.ecr.us-east-1.amazonaws.com/slava_mega_test:ray-meson-perf-debug`
(pulling it needs ECR access to account 411727469413). Verified to build on that base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)